### PR TITLE
fix run.sh to init the db on a new instance

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -32,25 +32,23 @@ fi
 
 # Initialising database
 if [[ "x"$MYSQL_USER != "x" && "x"$MYSQL_PASSWORD != "x" && "x"$MYSQL_DATABASE != "x" ]]; then
-    if [[ ! -x /.pdns-db-init ]]; then
+    echo >&2 "Checking for previous database init"
+    if [ ! -f /.pdns-db-init ]; then
         sleep 5
-        touch /.pdns-db-init
-        echo >&2 "Parameters detected"
+        echo >&2 "Previous database init not detected. Parameters detected"
 
-        export PARAM_MYSQLOK=`mysql --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute="SHOW DATABASES;"|grep -o "Database"`
         export PARAM_MYSQLDBOK=`mysql --host=${MYSQL_HOST} --port=${MYSQL_PORT} --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute="SHOW DATABASES;"|grep -o "${MYSQL_DATABASE}"`
 
-        if [ "$PARAM_MYSQLOK" != "Database" ]; then
+        if [ "$PARAM_MYSQLDBOK" != "$MYSQL_DATABASE" ]; then
             echo >&2 "Failed to connect to Database"
             exit 1
         fi
 
-        if [[ "$PARAM_MYSQLDBOK" != "$MYSQL_DATABASE" ]]; then
-            echo >&2 "Initialising DB"
-            sed -i -e "s:\[dbname\]:${MYSQL_DATABASE}:g" /pdns.sql
-            mysql --host=$MYSQL_HOST --port=${MYSQL_PORT} --user=$MYSQL_USER --password=$MYSQL_PASSWORD $MYSQL_DATABASE < /pdns.sql
-            sleep 4
-        fi
+        echo >&2 "Initialising DB"
+        sed -i -e "s:\[dbname\]:${MYSQL_DATABASE}:g" /pdns.sql
+        mysql --host=$MYSQL_HOST --port=${MYSQL_PORT} --user=$MYSQL_USER --password=$MYSQL_PASSWORD $MYSQL_DATABASE < /pdns.sql
+        sleep 4
+        touch /.pdns-db-init
     fi
 fi
 


### PR DESCRIPTION
Hi, this PowerDNS container works great, thanks for putting it together.  

I did find that when running as a stack that sometimes the mysql instance took longer then 5 seconds to finish starting.  If this happened the .pdns-db-init file would get created, but the run.sh would error and stop the container.  

When the powerdns container restarted the run.sh would skip the incomplete DB init section, so PowerDNS would never start. 

I moved the touch command to after the sql had run successfully and removed the first `SHOW DATABASES`, since the second one pretty much accomplishes the same thing. 
