### PR TITLE
build fail workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM exira/base:latest
+# fetch latest tag release as 'latest' fails
+# FROM exira/base:latest
+FROM exira/base:3.4.2
 
 MAINTAINER exira.com <info@exira.com>
 


### PR DESCRIPTION
If it can be of use... the 'latest' tag doesn't register on docker.io so to achieve build, use a known tag version.